### PR TITLE
Fix file header line for ELPA compatibility

### DIFF
--- a/eldoc-eval.el
+++ b/eldoc-eval.el
@@ -1,4 +1,4 @@
-;;; eldoc-eval.el -- Show eldoc when using M-:
+;;; eldoc-eval.el --- Show eldoc when using M-:
 
 ;; Copyright (C) 2011 Free Software Foundation, Inc.
 


### PR DESCRIPTION
A triple-dash is required by the `package-buffer-info` function.
