### PR TITLE
Give group to eldoc-in-minibuffer-mode

### DIFF
--- a/eldoc-eval.el
+++ b/eldoc-eval.el
@@ -193,6 +193,7 @@ See `with-eldoc-in-minibuffer'."
 (define-minor-mode eldoc-in-minibuffer-mode
     "Show eldoc for current minibuffer input."
   :global t
+  :group 'eldoc-eval
   (if eldoc-in-minibuffer-mode
       (progn
         (add-hook 'minibuffer-exit-hook


### PR DESCRIPTION
So all the customizable options are in one place, otherwise there will be a separate group called eldoc-in-minibuffer-mode created.